### PR TITLE
fix: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm start
 ```
 
 ```bash
-npm run servive-runner
+npm run service-runner
 # Runs MultiGeth service, configured to ETC mainnet by default.
 # Runs at http://localhost:8002/
 ```

--- a/README.md
+++ b/README.md
@@ -4,35 +4,79 @@
   <p><a href="https://jade.builders"><img alt="jade logo" src="https://raw.githubusercontent.com/etclabscore/jade-media-assets/master/jade-logo-light/jade-logo-light%20(PNG)/256x256.png" alt="jade.builders" width="125"></a></p>
 </h1>
 
-The goal of Jade is to provide a suite of tools to enable the creation of truly peer-to-peer applications on top of EVM-based blockchains like Ethereum Classic.
+Pristine-typescript-react-jade is a starting point for new and existing projects to create peer-to-peer decentralized applications. This repo is a a fork of [pristine-typescript-react](https://github.com/etclabscore/pristine-typescript-react) and utitlizes [Jade](https://jade.builders/), a suite of tooling for DApps. 
 
-This is an open source repository in its original condition. It leverages Typescript React, and [Jade](https://jade.builders) to give a good starting point for new and existing projects for peer-to-peer decentralized applications.
-
-Pristine Typescript React Jade is a fork of [etclabscore/pristine-typescript-react](https://github.com/etclabscore/pristine-typescript-react).
-
-There are a lack of repositories to start from to build community driven open source projects. Pristine Typescript React Jade is a complete starting point, it follows a Documentation Driven Development approach, and can be used as a resource to augment existing documentation.
-
+The goal of [Jade](https://jade.builders) is to provide a suite of tools to enable the creation of truly peer-to-peer applications on top of EVM-based blockchains like Ethereum Classic.
 
 ## Screenshot
 <h1 align="center">
-  <img src="https://user-images.githubusercontent.com/364566/60776464-53787600-a0e1-11e9-9db3-44874d217b3a.png">
+  <img src="https://github.com/etclabscore/jade-media-assets/blob/master/screenshots/p-tsc-react-jade-exampleDApp.png?raw=true">
 </h1>
 
+## Install
 
-## How to use Pristine in your project
+While the repo can be downloaded, cloned, or forked, the [Pritine-CLI](https://github.com/etclabscore/pristine-cli) makes it super easy to select a Pristine based template and related repositories.
 
-There are 3 options for using pristine with your project.
-1. Fork this repo as the start of your own, OR
-2. [follow these instructions](https://thoughts.t37.net/merging-2-different-git-repositories-without-losing-your-history-de7a06bba804) to use it on an existing repository.
-3. Use the `Use this template` button on this repository.
+### Dependencies
 
-## Documentation Driven Development
+- at least node `v10.15.3`
+- at least npm `v6.4.1`
+- [pristine-cli](https://github.com/etclabscore/pristine-cli) (recommended)
 
-There are many ways to drive open source development. Documenting the problem in the README gives a middle ground between technical and non-technical specifications. This allows organizing solutions to this challenge around community and documentation.
+Generate a project based on `pristine-typescript-react-jade` with the [Pritine-CLI](https://github.com/etclabscore/pristine-cli).
 
-> [...] a beautifully crafted library with no documentation is also damn near worthless. If your software solves the wrong problem or nobody can figure out how to use it, there’s something very bad going on.
+```bash
+pristine-cli <PROJECT NAME>
 
-- [Readme Driven Development](http://tom.preston-werner.com/2010/08/23/readme-driven-development.html) by Tom Preson-Werner
+# Follow the prompts and
+# select 'pristine-typescript-react-jade'
+```
+
+<h1 align="center">
+  <img src="https://github.com/etclabscore/jade-media-assets/blob/master/screenshots/pristine-cli-generate-jade-project.gif?raw=true">
+</h1>
+
+## Usage
+
+Install package dependencies. 
+
+```bash
+npm install
+```
+
+The project utilizes [Jade Servive Runner](https://github.com/etclabscore/jade-service-runner) to run an EVM based client in the background.  To run the app and background-service, run the following commands seperately.
+
+```bash
+npm start
+# Runs instance of the app http://localhost:3000/
+```
+
+```bash
+npm run servive-runner
+# Runs MultiGeth service, configured to ETC mainnet by default.
+# Runs at http://localhost:8002/
+```
+
+Where's the blockchain data? _Jade Service Runner_ conveniently creates and stores service data in the `/services/` directory in the project.
+
+```bash
+.
+├── node_modules
+├── public
+├── services
+│   └── multi-geth *
+└── src
+```
+
+## Contributing
+
+### Getting Started
+
+To get started, [fork](https://help.github.com/articles/fork-a-repo/) or [duplicate](https://help.github.com/articles/duplicating-a-repository/) the repository. Then edit this file and delete everything above this line.
+
+Then edit the `package.json` and change the `name` and `homepage` fields to match your newly created repository.
+
+How to contribute, build and release are outlined in [CONTRIBUTING.md](CONTRIBUTING.md), [BUILDING.md](BUILDING.md) and [RELEASING.md](RELEASING.md) respectively. Commits in this repository follow the [CONVENTIONAL_COMMITS.md](CONVENTIONAL_COMMITS.md) specification.
 
 ### Conventions and Specifications
 
@@ -45,8 +89,12 @@ Using conventions, documentation and specifications make it easier to:
 - promote open source contribution and engagement
 - promote issue and feature discussion on Github itself
 
-#### Resources
+### Resources
+- [Generate Pristine based Projects with the Pristine-CLI](https://www.youtube.com/watch?v=vdNJp2_gvTM)
+- [Pristine-CLI repo](https://github.com/etclabscore/pristine-cli)
+- [Jade Service Runner repo](https://github.com/etclabscore/jade-service-runner)
 
+Documenation Driven Development:
 - [Pristine](https://github.com/etclabscore/pristine)
 - [opensource.guide](https://opensource.guide/)
 - [Github community profiles for public repositories](https://help.github.com/articles/about-community-profiles-for-public-repositories/)
@@ -57,22 +105,3 @@ Using conventions, documentation and specifications make it easier to:
 - [Hammock Driven Development](https://www.youtube.com/watch?v=f84n5oFoZBc)
 - [Inversion and The Power of Avoiding Stupidity](https://fs.blog/2013/10/inversion/)
 - [choosealicense.com](http://choosealicense.com)
-
-## Getting Started
-
-To get started, [fork](https://help.github.com/articles/fork-a-repo/) or [duplicate](https://help.github.com/articles/duplicating-a-repository/) the repository. Then edit this file and delete everything above this line.
-
-Then edit the `package.json` and change the `name` and `homepage` fields to match your newly created repository.
-
-### Contributing
-
-How to contribute, build and release are outlined in [CONTRIBUTING.md](CONTRIBUTING.md), [BUILDING.md](BUILDING.md) and [RELEASING.md](RELEASING.md) respectively. Commits in this repository follow the [CONVENTIONAL_COMMITS.md](CONVENTIONAL_COMMITS.md) specification.
-
-## Usage
-
-This project requires the service runner, it is packaged as a command in the `package.json`.
-
-To get it up and running run the following commands separately:
-
-- `npm start`
-- `npm run service-runner`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Install package dependencies.
 npm install
 ```
 
-The project utilizes [Jade Servive Runner](https://github.com/etclabscore/jade-service-runner) to run an EVM based client in the background.  To run the app and background-service, run the following commands seperately.
+The project utilizes [Jade Service Runner](https://github.com/etclabscore/jade-service-runner) to run an EVM based client in the background.  To run the app and background-service, run the following commands seperately.
 
 ```bash
 npm start

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pristine Typescript React Jade
+# Pristine TypeScript React Jade
 
 <h1 align="center">
   <p><a href="https://jade.builders"><img alt="jade logo" src="https://raw.githubusercontent.com/etclabscore/jade-media-assets/master/jade-logo-light/jade-logo-light%20(PNG)/256x256.png" alt="jade.builders" width="125"></a></p>


### PR DESCRIPTION
I've made some changes to the readme. 
- images are now hosted in [jade-media-assets](https://github.com/etclabscore/jade-media-assets/tree/master/screenshots)
- removed some of the pristine content, seemed too out of context to the project but I retained most of it to sound more specific to the actual repo
- updated Usage and added Install sections